### PR TITLE
fix(AuthService): fix base-url and rename service

### DIFF
--- a/coverprofile.out
+++ b/coverprofile.out
@@ -45,7 +45,7 @@ github.com/j-flat/go-veikkaus/internal/veikkausapi/response_handler.go:23.16,25.
 github.com/j-flat/go-veikkaus/internal/veikkausapi/response_handler.go:27.2,27.53 1 3
 github.com/j-flat/go-veikkaus/internal/veikkausapi/response_handler.go:27.53,29.3 1 2
 github.com/j-flat/go-veikkaus/internal/veikkausapi/response_handler.go:31.2,31.12 1 1
-github.com/j-flat/go-veikkaus/veikkaus/login.go:24.82,34.16 4 0
+github.com/j-flat/go-veikkaus/veikkaus/login.go:24.81,34.16 4 0
 github.com/j-flat/go-veikkaus/veikkaus/login.go:34.16,37.3 2 0
 github.com/j-flat/go-veikkaus/veikkaus/login.go:39.2,41.16 2 0
 github.com/j-flat/go-veikkaus/veikkaus/login.go:41.16,44.3 2 0
@@ -69,4 +69,4 @@ github.com/j-flat/go-veikkaus/veikkaus/veikkaus.go:77.2,77.22 1 0
 github.com/j-flat/go-veikkaus/veikkaus/veikkaus.go:77.22,79.3 1 0
 github.com/j-flat/go-veikkaus/veikkaus/veikkaus.go:80.2,80.23 1 0
 github.com/j-flat/go-veikkaus/veikkaus/veikkaus.go:80.23,82.3 1 0
-github.com/j-flat/go-veikkaus/veikkaus/veikkaus.go:83.2,84.38 2 0
+github.com/j-flat/go-veikkaus/veikkaus/veikkaus.go:83.2,84.36 2 0

--- a/veikkaus/login.go
+++ b/veikkaus/login.go
@@ -19,9 +19,9 @@ type LoginPayload struct {
 
 type LoginSuccessful = map[string]interface{}
 
-type LoginService service
+type AuthService service
 
-func (s *LoginService) Login(username, password string) (LoginSuccessful, error) {
+func (s *AuthService) Login(username, password string) (LoginSuccessful, error) {
 	client := http.Client{}
 	payloadStruct := LoginPayload{
 		Type:     "STANDARD_LOGIN",

--- a/veikkaus/veikkaus.go
+++ b/veikkaus/veikkaus.go
@@ -13,7 +13,7 @@ const (
 
 	// API Basic Configuration
 	defaultAPIVersion = veikkausapi.VeikkausAPIVersion
-	defaultBaseURL    = veikkausapi.VeikkausApiBaseUrl + "/" + defaultAPIVersion
+	defaultBaseURL    = veikkausapi.VeikkausApiBaseUrl + defaultAPIVersion
 	defaultUserAgent  = "go-veikkaus" + Version
 
 	// Header configurations
@@ -46,7 +46,7 @@ type Client struct {
 	common service
 
 	// Services used for interacting with different endpoints on Veikkaus API
-	Login *LoginService
+	Auth *AuthService
 }
 
 type service struct {
@@ -81,7 +81,7 @@ func (c *Client) initialize() {
 		c.UserAgent = defaultUserAgent
 	}
 	c.common.client = c
-	c.Login = (*LoginService)(&c.common)
+	c.Auth = (*AuthService)(&c.common)
 }
 
 // func (c *Client) copy() *Client {


### PR DESCRIPTION
Rename LoginService to AuthService for nicer client API.

BaseURL had extra slash on it.